### PR TITLE
peer dependency supports newer grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "node-chrome-runner": "^0.0.5"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   }
 }


### PR DESCRIPTION
Per grunt recommendations now that they've released 1.0 - https://github.com/gruntjs/grunt/blob/ac9de1240b7aa286995742e2424aa2138a521c11/CHANGELOG#L10

Already did this for grunt-jasmine-firefoxaddon since I have permissions both over your repo and the npm package for it, but sending the pull request for chromeapp since I don't. Not urgent, but will prevent future semi-mysterious build breakage for people who do something like `ncu --upgradeAll` while depending on this module.
